### PR TITLE
Add configuration for checkbox initial state

### DIFF
--- a/Magewire/SubscribeInfo.php
+++ b/Magewire/SubscribeInfo.php
@@ -1,7 +1,10 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * @copyright   Copyright (c) Vendic B.V https://vendic.nl/
  */
+
+declare(strict_types=1);
 
 namespace Vendic\HyvaCheckoutNewsletterSubscribe\Magewire;
 

--- a/Magewire/SubscribeInput.php
+++ b/Magewire/SubscribeInput.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Vendic\HyvaCheckoutNewsletterSubscribe\Magewire;
 
 use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Store\Model\StoreManagerInterface;
 use Magewirephp\Magewire\Component;
 use Vendic\HyvaCheckoutNewsletterSubscribe\Model\Config;
 
@@ -23,14 +24,17 @@ class SubscribeInput extends Component
 
     public function __construct(
         private CheckoutSession $checkoutSession,
+        private StoreManagerInterface $storeManager,
         private Config $config
     ) {
     }
 
     public function mount(): void
     {
-        $this->subscribed
-            = $this->checkoutSession->getData(self::IS_SUBSCRIBED_KEY) ?? $this->config->isCheckboxInitiallyEnabled();
+        $storeId = (int)$this->storeManager->getStore()->getId();
+
+        $this->subscribed = $this->checkoutSession->getData(self::IS_SUBSCRIBED_KEY) ??
+            $this->config->isCheckboxInitiallyEnabled($storeId);
 
         $this->checkoutSession->setData(self::IS_SUBSCRIBED_KEY, $this->subscribed);
     }

--- a/Magewire/SubscribeInput.php
+++ b/Magewire/SubscribeInput.php
@@ -31,6 +31,8 @@ class SubscribeInput extends Component
     {
         $this->subscribed
             = $this->checkoutSession->getData(self::IS_SUBSCRIBED_KEY) ?? $this->config->isCheckboxInitiallyEnabled();
+
+        $this->checkoutSession->setData(self::IS_SUBSCRIBED_KEY, $this->subscribed);
     }
 
     public function updatedSubscribed(mixed $value) : mixed

--- a/Magewire/SubscribeInput.php
+++ b/Magewire/SubscribeInput.php
@@ -1,29 +1,36 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * @copyright   Copyright (c) Vendic B.V https://vendic.nl/
  */
+
+declare(strict_types=1);
 
 namespace Vendic\HyvaCheckoutNewsletterSubscribe\Magewire;
 
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magewirephp\Magewire\Component;
+use Vendic\HyvaCheckoutNewsletterSubscribe\Model\Config;
 
 class SubscribeInput extends Component
 {
     public const IS_SUBSCRIBED_KEY = 'is_subscribed';
 
     /**
-     * @var bool
+     * @var bool|null
      */
-    public $subscribed;
+    public $subscribed = null;
 
-    public function __construct(private CheckoutSession $checkoutSession)
-    {
+    public function __construct(
+        private CheckoutSession $checkoutSession,
+        private Config $config
+    ) {
     }
 
     public function mount(): void
     {
-        $this->subscribed = $this->checkoutSession->getData(self::IS_SUBSCRIBED_KEY) ?: false;
+        $this->subscribed
+            = $this->checkoutSession->getData(self::IS_SUBSCRIBED_KEY) ?? $this->config->isCheckboxInitiallyEnabled();
     }
 
     public function updatedSubscribed(mixed $value) : mixed

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright   Copyright (c) Vendic B.V https://vendic.nl/
+ */
+
+declare(strict_types=1);
+
+namespace Vendic\HyvaCheckoutNewsletterSubscribe\Model;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class Config
+{
+    private const string HYVA_CHECKOUT_NEWSLETTER_SUBSCRIBE_IS_CHECKBOX_INITIALLY_ENABLED = 'hyva_checkout_newsletter_subscribe/general/enabled';
+
+    public function __construct(
+        private ScopeConfigInterface $scopeConfig
+    ) {
+    }
+
+    public function isCheckboxInitiallyEnabled(int $store = 0): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::HYVA_CHECKOUT_NEWSLETTER_SUBSCRIBE_IS_CHECKBOX_INITIALLY_ENABLED,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+}

--- a/Model/Form/Field/HideSubscribeInfoModifier.php
+++ b/Model/Form/Field/HideSubscribeInfoModifier.php
@@ -1,4 +1,10 @@
-<?php declare(strict_types=1);
+<?php
+
+/**
+ * @copyright   Copyright (c) Vendic B.V https://vendic.nl/
+ */
+
+declare(strict_types=1);
 
 namespace Vendic\HyvaCheckoutNewsletterSubscribe\Model\Form\Field;
 

--- a/Plugin/AddSubscriberToNewsletter.php
+++ b/Plugin/AddSubscriberToNewsletter.php
@@ -42,7 +42,7 @@ class AddSubscriberToNewsletter
         try {
             $this->isLoggedInCustomer() ?
                 $this->subscriptionManager->subscribeCustomer(
-                    $this->checkoutSession->getQuote()->getCustomerId(),
+                    (int)$this->checkoutSession->getQuote()->getCustomerId(),
                     $storeId
                 ) :
                 $this->subscriptionManager->subscribe($email, $storeId);

--- a/Plugin/AddSubscriberToNewsletter.php
+++ b/Plugin/AddSubscriberToNewsletter.php
@@ -1,7 +1,10 @@
 <?php
+
 /**
  * @copyright   Copyright (c) Vendic B.V https://vendic.nl/
  */
+
+declare(strict_types=1);
 
 namespace Vendic\HyvaCheckoutNewsletterSubscribe\Plugin;
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Adds a newsletter subscribe checkbox on the [Hyvä checkout](https://www.hyva.io
 composer require vendic/hyva-checkout-newsletter-subscribe
 ```
 
-## Admin Configuration
-
-This module doesn't have any admin settings, it's enabled by default after install.
+## Configuration
+You can set initial state of checkbox in `Stores > Configuration > Vendic > Hyva Checkout Newsletter Subscribe`:
+- `Is subscribe newsletter checkbox enabled by default (initially)` - set to `Yes` if you want the checkbox to be checked by default.
 
 ## Screenshot
 ![Screenshot](./media/screenshot.png)

--- a/Service/NewsletterSubscriptionChecker.php
+++ b/Service/NewsletterSubscriptionChecker.php
@@ -1,4 +1,10 @@
-<?php declare(strict_types=1);
+<?php
+
+/**
+ * @copyright   Copyright (c) Vendic B.V https://vendic.nl/
+ */
+
+declare(strict_types=1);
 
 namespace  Vendic\HyvaCheckoutNewsletterSubscribe\Service;
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+    ~ Copyright (c) Vendic B.V https://vendic.nl/
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <tab id="vendic" translate="label" sortOrder="10">
+            <label>Vendic</label>
+        </tab>
+        <section id="hyva_checkout_newsletter_subscribe" translate="label" sortOrder="1000"
+                 showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Hyva Checkout Newsletter Subscribe</label>
+            <tab>vendic</tab>
+            <resource>Vendic_HyvaCheckoutNewsletterSubscribe::config</resource>
+            <group id="general" translate="label" sortOrder="10" showInStore="1" showInWebsite="1"
+                   showInDefault="1" type="text">
+                <label>General</label>
+                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1"
+                       showInWebsite="1" showInStore="1">
+                    <label>Is subscribe newsletter checkbox enabled by default (initially)</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+    ~ Copyright (c) Vendic B.V https://vendic.nl/
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <hyva_checkout_newsletter_subscribe>
+            <general>
+                <enabled>0</enabled>
+            </general>
+        </hyva_checkout_newsletter_subscribe>
+    </default>
+</config>

--- a/view/frontend/templates/magewire/subscribe-input.phtml
+++ b/view/frontend/templates/magewire/subscribe-input.phtml
@@ -8,7 +8,7 @@ $inputCssClasses = $block->getData('input_css_classes');
 ?>
 <div>
     <input
-        <?php if ($inputCssClasses) : ?>
+        <?php if ($inputCssClasses): ?>
             class="<?= $escaper->escapeHtmlAttr($inputCssClasses) ?>"
         <?php endif; ?>
         wire:model="subscribed"


### PR DESCRIPTION
It is possible to set initial state of checkbox in `Stores > Configuration > Vendic > Hyva Checkout Newsletter Subscribe`:
- `Is subscribe newsletter checkbox enabled by default (initially)` - set to `Yes` if you want the checkbox to be checked by default.