### PR TITLE
SWEMW-216: Hide newsletter subscription block on the checkout if newsletter is disabled

### DIFF
--- a/view/frontend/layout/hyva_checkout_components.xml
+++ b/view/frontend/layout/hyva_checkout_components.xml
@@ -4,7 +4,7 @@
     <body>
         <referenceContainer name="checkout.section.quote-actions">
             <container name="newsletter.subscribe.wrapper" htmlTag="div" htmlClass="mt-4">
-                <block name="newsletter.subscribe.info" as="info">
+                <block name="newsletter.subscribe.info" as="info" ifconfig="newsletter/general/active">
                     <arguments>
                         <argument name="magewire" xsi:type="object">
                             Vendic\HyvaCheckoutNewsletterSubscribe\Magewire\SubscribeInfo


### PR DESCRIPTION
Conditionally hides the newsletter subscription block on checkout when newsletter is disabled in Magento configuration                                                     Adds `ifconfig="newsletter/general/active"` to the newsletter block in the layout XML