### PR TITLE
PHP 8.1 and 8.2 compatibility for class constant

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -13,7 +13,7 @@ use Magento\Store\Model\ScopeInterface;
 
 class Config
 {
-    private const string HYVA_CHECKOUT_NEWSLETTER_SUBSCRIBE_IS_CHECKBOX_INITIALLY_ENABLED = 'hyva_checkout_newsletter_subscribe/general/enabled';
+    private const HYVA_CHECKOUT_NEWSLETTER_SUBSCRIBE_IS_CHECKBOX_INITIALLY_ENABLED = 'hyva_checkout_newsletter_subscribe/general/enabled';
 
     public function __construct(
         private ScopeConfigInterface $scopeConfig


### PR DESCRIPTION
Removed type for class constant, because it's introduced in PHP 8.3. The coomposer.json indicates that PHP 8.1 through 8.5 are supported. However, you'll receive an error if you use PHP 8.1 or 8.2, because of the typed class constant.

https://php.watch/versions/8.3/typed-constants